### PR TITLE
Splitting into package

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -1,8 +1,10 @@
-package ionic
+package events
 
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/ion-channel/ionic/users"
 )
 
 // Event represents a singular occurance of a change within the Ion Channel
@@ -80,7 +82,7 @@ func (a *UserEventAction) UnmarshalJSON(b []byte) error {
 // UserEvent represents the user releated segement of an Event within Ion Channel
 type UserEvent struct {
 	Action UserEventAction `json:"action"`
-	User   User            `json:"user"`
+	User   users.User      `json:"user"`
 	Link   string          `json:"link"`
 	Team   string          `json:"team"`
 }

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -1,4 +1,4 @@
-package ionic
+package events
 
 import (
 	"encoding/json"

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -1,4 +1,4 @@
-package ionic
+package rules
 
 import (
 	"net/url"

--- a/rulesets.go
+++ b/rulesets.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"time"
+
+	"github.com/ion-channel/ionic/rulesets"
 )
 
 const (
@@ -13,18 +14,7 @@ const (
 	getRuleSetsEndpoint       = "v1/ruleset/getRulesets"
 )
 
-type RuleSet struct {
-	ID          string    `json:"id"`
-	TeamID      string    `json:"team_id"`
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	RuleIDs     []string  `json:"rule_ids"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
-	Rules       []Rule    `json:"rules"`
-}
-
-func (ic *IonClient) GetRuleSet(id, teamID string) (*RuleSet, error) {
+func (ic *IonClient) GetRuleSet(id, teamID string) (*rulesets.RuleSet, error) {
 	params := &url.Values{}
 	params.Set("id", id)
 	params.Set("team_id", teamID)
@@ -34,7 +24,7 @@ func (ic *IonClient) GetRuleSet(id, teamID string) (*RuleSet, error) {
 		return nil, fmt.Errorf("failed to get rulesets: %v", err.Error())
 	}
 
-	var rs RuleSet
+	var rs rulesets.RuleSet
 	err = json.Unmarshal(b, &rs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rulesets: %v", err.Error())
@@ -43,7 +33,7 @@ func (ic *IonClient) GetRuleSet(id, teamID string) (*RuleSet, error) {
 	return &rs, nil
 }
 
-func (ic *IonClient) GetRuleSets(teamID string) ([]RuleSet, error) {
+func (ic *IonClient) GetRuleSets(teamID string) ([]rulesets.RuleSet, error) {
 	params := &url.Values{}
 	params.Set("team_id", teamID)
 
@@ -52,7 +42,7 @@ func (ic *IonClient) GetRuleSets(teamID string) ([]RuleSet, error) {
 		return nil, fmt.Errorf("failed to get rulesets: %v", err.Error())
 	}
 
-	var rs []RuleSet
+	var rs []rulesets.RuleSet
 	err = json.Unmarshal(b, &rs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rulesets: %v", err.Error())

--- a/rulesets/rulesets.go
+++ b/rulesets/rulesets.go
@@ -1,0 +1,18 @@
+package rulesets
+
+import (
+	"time"
+
+	"github.com/ion-channel/ionic/rules"
+)
+
+type RuleSet struct {
+	ID          string       `json:"id"`
+	TeamID      string       `json:"team_id"`
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	RuleIDs     []string     `json:"rule_ids"`
+	CreatedAt   time.Time    `json:"created_at"`
+	UpdatedAt   time.Time    `json:"updated_at"`
+	Rules       []rules.Rule `json:"rules"`
+}

--- a/sessions.go
+++ b/sessions.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/ion-channel/ionic/users"
 )
 
 const (
@@ -14,8 +16,8 @@ const (
 
 // Session represents the BearerToken and User for the current session
 type Session struct {
-	BearerToken string `json:"jwt"`
-	User        User   `json:"user"`
+	BearerToken string     `json:"jwt"`
+	User        users.User `json:"user"`
 }
 
 type loginRequest struct {

--- a/users.go
+++ b/users.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+
+	"github.com/ion-channel/ionic/events"
+	"github.com/ion-channel/ionic/users"
 )
 
 const (
@@ -11,19 +14,10 @@ const (
 	usersGetSelfEndpoint            = "v1/users/getSelf"
 )
 
-// User is a representation of an Ion Channel User within the system
-type User struct {
-	ID         string `json:"id"`
-	Email      string `json:"email"`
-	Username   string `json:"username"`
-	ChatHandle string `json:"chat_handle"`
-	SysAdmin   bool   `json:"sys_admin"`
-}
-
 // GetUsersSubscribedForEvent takes an event and returns a list of users
 // subscribed to that event and returns an error if there are JSON marshalling
 // or unmarshalling issues or issues with the request
-func (ic *IonClient) GetUsersSubscribedForEvent(event Event) ([]User, error) {
+func (ic *IonClient) GetUsersSubscribedForEvent(event events.Event) ([]users.User, error) {
 	b, err := json.Marshal(event)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal event to JSON: %v", err.Error())
@@ -36,7 +30,7 @@ func (ic *IonClient) GetUsersSubscribedForEvent(event Event) ([]User, error) {
 	}
 
 	var users struct {
-		Users []User `json:"users"`
+		Users []users.User `json:"users"`
 	}
 	err = json.Unmarshal(b, &users)
 	if err != nil {
@@ -49,13 +43,13 @@ func (ic *IonClient) GetUsersSubscribedForEvent(event Event) ([]User, error) {
 // GetSelf returns the user object associated with the bearer token in use by
 // the Ion Client.  An error is returned if the client cannot talk to the API
 // or the returned user object is nil or blank
-func (ic *IonClient) GetSelf() (*User, error) {
+func (ic *IonClient) GetSelf() (*users.User, error) {
 	b, err := ic.get(usersGetSelfEndpoint, nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get self: %v", err.Error())
 	}
 
-	var user User
+	var user users.User
 	err = json.Unmarshal(b, &user)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse user: %v", err.Error())

--- a/users/users.go
+++ b/users/users.go
@@ -1,0 +1,10 @@
+package users
+
+// User is a representation of an Ion Channel User within the system
+type User struct {
+	ID         string `json:"id"`
+	Email      string `json:"email"`
+	Username   string `json:"username"`
+	ChatHandle string `json:"chat_handle"`
+	SysAdmin   bool   `json:"sys_admin"`
+}

--- a/users_test.go
+++ b/users_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/ion-channel/ionic/events"
+
 	. "github.com/franela/goblin"
 	"github.com/gomicro/bogus"
 	. "github.com/onsi/gomega"
@@ -25,7 +27,7 @@ func TestUsers(t *testing.T) {
 				SetMethods("POST").
 				SetPayload([]byte(SampleUsersForEventResponse)).
 				SetStatus(http.StatusOK)
-			e := Event{}
+			e := events.Event{}
 
 			users, err := client.GetUsersSubscribedForEvent(e)
 			Expect(err).To(BeNil())

--- a/vulnerabilities.go
+++ b/vulnerabilities.go
@@ -9,7 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"time"
+
+	"github.com/ion-channel/ionic/vulnerabilities"
 )
 
 const (
@@ -18,36 +19,11 @@ const (
 	getVulnerabilityEndpoint         = "v1/vulnerability/getVulnerability"
 )
 
-// Vulnerability represents a singular vulnerability record in the Ion Channel
-// Platform
-type Vulnerability struct {
-	ID                          int             `json:"id"`
-	ExternalID                  string          `json:"external_id"`
-	Title                       string          `json:"title"`
-	Summary                     string          `json:"summary"`
-	Score                       string          `json:"score"`
-	Vector                      string          `json:"vector"`
-	AccessComplexity            string          `json:"access_complexity"`
-	VulnerabilityAuthentication string          `json:"vulnerability_authentication"`
-	ConfidentialityImpact       string          `json:"confidentiality_impact"`
-	IntegrityImpact             string          `json:"integrity_impact"`
-	AvailabilityImpact          string          `json:"availability_impact"`
-	VulnerabilitySource         string          `json:"vulnerabilty_source"`
-	AssessmentCheck             json.RawMessage `json:"assessment_check"`
-	Scanner                     json.RawMessage `json:"scanner"`
-	Recommendation              string          `json:"recommendation"`
-	ModifiedAt                  time.Time       `json:"modified_at"`
-	PublishedAt                 time.Time       `json:"published_at"`
-	CreatedAt                   time.Time       `json:"created_at"`
-	UpdatedAt                   time.Time       `json:"updated_at"`
-	SourceID                    int             `json:"source_id"`
-}
-
 // GetVulnerabilities returns a slice of Vulnerability for a given product and
 // version string over a specified pagination range.  If version is left blank,
 // it will not be considered in the search query.  An error is returned for
 // client communication and unmarshalling errors.
-func (ic *IonClient) GetVulnerabilities(product, version string, pagination *Pagination) ([]Vulnerability, error) {
+func (ic *IonClient) GetVulnerabilities(product, version string, pagination *Pagination) ([]vulnerabilities.Vulnerability, error) {
 	params := &url.Values{}
 	params.Set("product", product)
 	if version != "" {
@@ -59,7 +35,7 @@ func (ic *IonClient) GetVulnerabilities(product, version string, pagination *Pag
 		return nil, fmt.Errorf("failed to get vulnerabilities: %v", err.Error())
 	}
 
-	var vulns []Vulnerability
+	var vulns []vulnerabilities.Vulnerability
 	err = json.Unmarshal(b, &vulns)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse vulnerabilities: %v", err.Error())
@@ -72,7 +48,7 @@ func (ic *IonClient) GetVulnerabilities(product, version string, pagination *Pag
 // a slice of vulnerabilities found for the list of dependencies.  An error is
 // returned if the file can't be cannot be read, the API returns an error, or
 // marshalling issues.
-func (ic *IonClient) GetVulnerabilitiesInFile(filePath string) ([]Vulnerability, error) {
+func (ic *IonClient) GetVulnerabilitiesInFile(filePath string) ([]vulnerabilities.Vulnerability, error) {
 	buff := &bytes.Buffer{}
 	bw := multipart.NewWriter(buff)
 
@@ -101,7 +77,7 @@ func (ic *IonClient) GetVulnerabilitiesInFile(filePath string) ([]Vulnerability,
 		return nil, fmt.Errorf("failed to get vulnerabilities: %v", err.Error())
 	}
 
-	var vulns []Vulnerability
+	var vulns []vulnerabilities.Vulnerability
 	err = json.Unmarshal(b, &vulns)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse vulnerabilities: %v", err.Error())
@@ -112,7 +88,7 @@ func (ic *IonClient) GetVulnerabilitiesInFile(filePath string) ([]Vulnerability,
 
 // GetVulnerability takes an ID string and returns the vulnerability found for
 // that ID.  An error is returned for API errors and marshalling errors.
-func (ic *IonClient) GetVulnerability(id string) (*Vulnerability, error) {
+func (ic *IonClient) GetVulnerability(id string) (*vulnerabilities.Vulnerability, error) {
 	params := &url.Values{}
 	params.Set("external_id", id)
 
@@ -121,7 +97,7 @@ func (ic *IonClient) GetVulnerability(id string) (*Vulnerability, error) {
 		return nil, fmt.Errorf("failed to get vulnerability: %v", err.Error())
 	}
 
-	var vuln Vulnerability
+	var vuln vulnerabilities.Vulnerability
 	err = json.Unmarshal(b, &vuln)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse vulnerability: %v", err.Error())

--- a/vulnerabilities/vulnerabilities.go
+++ b/vulnerabilities/vulnerabilities.go
@@ -1,0 +1,31 @@
+package vulnerabilities
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Vulnerability represents a singular vulnerability record in the Ion Channel
+// Platform
+type Vulnerability struct {
+	ID                          int             `json:"id"`
+	ExternalID                  string          `json:"external_id"`
+	Title                       string          `json:"title"`
+	Summary                     string          `json:"summary"`
+	Score                       string          `json:"score"`
+	Vector                      string          `json:"vector"`
+	AccessComplexity            string          `json:"access_complexity"`
+	VulnerabilityAuthentication string          `json:"vulnerability_authentication"`
+	ConfidentialityImpact       string          `json:"confidentiality_impact"`
+	IntegrityImpact             string          `json:"integrity_impact"`
+	AvailabilityImpact          string          `json:"availability_impact"`
+	VulnerabilitySource         string          `json:"vulnerabilty_source"`
+	AssessmentCheck             json.RawMessage `json:"assessment_check"`
+	Scanner                     json.RawMessage `json:"scanner"`
+	Recommendation              string          `json:"recommendation"`
+	ModifiedAt                  time.Time       `json:"modified_at"`
+	PublishedAt                 time.Time       `json:"published_at"`
+	CreatedAt                   time.Time       `json:"created_at"`
+	UpdatedAt                   time.Time       `json:"updated_at"`
+	SourceID                    int             `json:"source_id"`
+}


### PR DESCRIPTION
Splits the project into packages based on the structs.

The ionic client is the primary package, and contains all of the ion clients methods.  Each of our other objects gets its own package to contain methods relevant to those objects.