### PR TITLE
remove unused Rule struct members

### DIFF
--- a/rules/rules.go
+++ b/rules/rules.go
@@ -11,8 +11,6 @@ type Rule struct {
 	Name           string    `json:"name"`
 	Description    string    `json:"description"`
 	Category       string    `json:"category"`
-	PolicyURL      string    `json:"policy_url"`
-	RemediationURL string    `json:"remediation_url"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
 }


### PR DESCRIPTION
i'm not sure if this breaks anything else downstream. i checked in the ui and removed any references, but didn't see anything that would actually break:

https://github.com/ion-channel/ion-ui/pull/887