### PR TITLE
Consistency Wins

### DIFF
--- a/reports/analysis_test.go
+++ b/reports/analysis_test.go
@@ -77,8 +77,8 @@ func TestAnalysisReport(t *testing.T) {
 				Expect(ar.ScanSummaries[0].Results).NotTo(BeNil())
 				Expect(len(ar.ScanSummaries[0].Results)).NotTo(Equal(0))
 
-				lr, ok := ar.ScanSummaries[0].TranslatedResults.Data.(*scans.LicenseResults)
-				Expect(ok).To(BeTrue())
+				lr, ok := ar.ScanSummaries[0].TranslatedResults.Data.(scans.LicenseResults)
+				Expect(ok).To(BeTrue(), "Expected LicenseResults type")
 				Expect(lr.Type).To(HaveLen(1))
 				Expect(lr.Type[0].Name).To(Equal("apache-2.0"))
 				Expect(lr.Name).To(Equal("LICENSE.md"))

--- a/scans/results.go
+++ b/scans/results.go
@@ -34,43 +34,43 @@ func (u *UntranslatedResults) Translate() *TranslatedResults {
 	// out in the name of explicit, easily-readable code.
 	if u.AboutYML != nil {
 		tr.Type = "about_yml"
-		tr.Data = u.AboutYML
+		tr.Data = *u.AboutYML
 	}
 	if u.Community != nil {
 		tr.Type = "community"
-		tr.Data = u.Community
+		tr.Data = *u.Community
 	}
 	if u.Coverage != nil {
 		tr.Type = "coverage"
-		tr.Data = u.Coverage
+		tr.Data = *u.Coverage
 	}
 	if u.Dependency != nil {
 		tr.Type = "dependency"
-		tr.Data = u.Dependency
+		tr.Data = *u.Dependency
 	}
 	if u.Difference != nil {
 		tr.Type = "difference"
-		tr.Data = u.Difference
+		tr.Data = *u.Difference
 	}
 	if u.Ecosystem != nil {
 		tr.Type = "ecosystems"
-		tr.Data = u.Ecosystem
+		tr.Data = *u.Ecosystem
 	}
 	if u.ExternalVulnerabilities != nil {
 		tr.Type = "external_vulnerability"
-		tr.Data = u.ExternalVulnerabilities
+		tr.Data = *u.ExternalVulnerabilities
 	}
 	if u.License != nil {
 		tr.Type = "license"
-		tr.Data = u.License
+		tr.Data = *u.License
 	}
 	if u.Virus != nil {
 		tr.Type = "virus"
-		tr.Data = u.Virus
+		tr.Data = *u.Virus
 	}
 	if u.Vulnerability != nil {
 		tr.Type = "vulnerability"
-		tr.Data = u.Vulnerability
+		tr.Data = *u.Vulnerability
 	}
 	return &tr
 }

--- a/scans/results_test.go
+++ b/scans/results_test.go
@@ -73,13 +73,9 @@ func TestScanResults(t *testing.T) {
 			Expect(translatedResult).NotTo(BeNil())
 			Expect(translatedResult.Type).To(Equal("license"))
 			Expect(translatedResult.Data).NotTo(BeNil())
-			wasLicenseResults := false
-			switch translatedResult.Data.(type) {
-			case *LicenseResults:
-				wasLicenseResults = true
-			}
-			Expect(wasLicenseResults).To(BeTrue())
-			licenseResults := translatedResult.Data.(*LicenseResults)
+
+			licenseResults, ok := translatedResult.Data.(LicenseResults)
+			Expect(ok).To(BeTrue(), "Expected LicenseResults type")
 			Expect(licenseResults.Type).To(HaveLen(1))
 			Expect(licenseResults.Type[0].Name).To(Equal("a license"))
 			Expect(licenseResults.Name).To(Equal("some license"))

--- a/scans/scans.go
+++ b/scans/scans.go
@@ -29,12 +29,7 @@ type scan struct {
 }
 
 // NewScan creates and returns a new Scan struct
-func NewScan(
-	id, teamID, projectID, analysisID, summary, name, description string,
-	results json.RawMessage,
-	createdAt, updatedAt time.Time,
-	duration float64,
-) (*Scan, error) {
+func NewScan(id, teamID, projectID, analysisID, summary, name, description string, results json.RawMessage, createdAt, updatedAt time.Time, duration float64) (*Scan, error) {
 	s := scan{
 		ID:          id,
 		TeamID:      teamID,
@@ -48,24 +43,26 @@ func NewScan(
 		Name:        name,
 		Description: description,
 	}
-	var tr TranslatedResults
 
-	var ur UntranslatedResults
-	err := json.Unmarshal(results, &ur)
+	var tr TranslatedResults
+	err := json.Unmarshal(results, &tr)
 	if err != nil {
-		err = json.Unmarshal(results, &tr)
+		var ur UntranslatedResults
+		err = json.Unmarshal(results, &ur)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get valid results: %v", err.Error())
 		}
-	} else {
-		tr = *ur.Translate()
-	}
-	bigS := &Scan{
-		scan:              &s,
-		TranslatedResults: &tr,
+
+		return &Scan{
+			scan:              &s,
+			TranslatedResults: ur.Translate(),
+		}, nil
 	}
 
-	return bigS, nil
+	return &Scan{
+		scan:              &s,
+		TranslatedResults: &tr,
+	}, nil
 }
 
 // Translate performs a one way translation on a scan by translating the


### PR DESCRIPTION
* Changes scan translate method to dereference pointers for data and match parity with our custom unmarshaller
* Updates New scan constructor to favor translated results over untranslated results like everywhere else