### PR TITLE
Remove ssh key checking

### DIFF
--- a/projects/projects.go
+++ b/projects/projects.go
@@ -1,9 +1,7 @@
 package projects
 
 import (
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -140,35 +138,6 @@ func (p *Project) Validate(client *http.Client, baseURL *url.URL, token string) 
 	r := regexp.MustCompile(validEmailRegex)
 	if p.POCEmail != "" && !r.MatchString(p.POCEmail) {
 		invalidFields["poc_email"] = "invalid email supplied"
-		projErr = ErrInvalidProject
-	}
-
-	isFinger, err := regexp.MatchString("[a-f0-9]{2}\\:[a-f0-9]{2}\\:[a-f0-9]{2}\\:", p.DeployKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to detect deploy key fingerprint: %v", err.Error())
-	}
-
-	if isFinger {
-		p.DeployKey = ""
-	}
-
-	block, rest := pem.Decode([]byte(p.DeployKey))
-	if block != nil {
-		pkey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
-		if err != nil {
-			invalidFields["deploy_key"] = "must be a valid ssh key"
-			projErr = ErrInvalidProject
-		} else {
-			err = pkey.Validate()
-			if err != nil {
-				invalidFields["deploy_key"] = "must be a valid ssh key"
-				projErr = ErrInvalidProject
-			}
-		}
-	}
-
-	if block == nil && rest != nil && string(rest) != "" {
-		invalidFields["deploy_key"] = "must be a valid ssh key"
 		projErr = ErrInvalidProject
 	}
 

--- a/projects/projects_test.go
+++ b/projects/projects_test.go
@@ -96,27 +96,6 @@ func TestProject(t *testing.T) {
 			Expect(fs["type"]).To(Equal("missing type"))
 		})
 
-		g.It("should say a project is invalid if a deploy key is invalid", func() {
-			server.AddPath("/v1/ruleset/getRuleset").
-				SetMethods("HEAD").
-				SetStatus(http.StatusOK)
-
-			var p Project
-			err := json.Unmarshal([]byte(fmt.Sprintf(sampleValidProject, host, port)), &p)
-			b, _ := url.Parse(fmt.Sprintf("http://%v:%v", host, port))
-			Expect(err).To(BeNil())
-
-			p.DeployKey = sampleInvalidKey
-			fs, err := p.Validate(client, b, testToken)
-			Expect(err).To(Equal(ErrInvalidProject))
-			Expect(fs["deploy_key"]).To(Equal("must be a valid ssh key"))
-
-			p.DeployKey = "not valid"
-			fs, err = p.Validate(client, b, testToken)
-			Expect(err).To(Equal(ErrInvalidProject))
-			Expect(fs["deploy_key"]).To(Equal("must be a valid ssh key"))
-		})
-
 		g.It("should return string in JSON", func() {
 			id := "someid"
 			teamID := "someteamiD"


### PR DESCRIPTION
This is a service's purview, especially when we add connectivity checking. No need to add the AWS SDK to this project if we can avoid it. 👍 