### PR TITLE
Fall back to scan status dates if analysis isn't present.

### DIFF
--- a/reports/analysis.go
+++ b/reports/analysis.go
@@ -27,6 +27,8 @@ func NewAnalysisReport(status *scanner.AnalysisStatus, analysis *analyses.Analys
 			ProjectID: status.ProjectID,
 			TeamID:    status.TeamID,
 			Status:    status.Status,
+			CreatedAt: status.CreatedAt,
+			UpdatedAt: status.UpdatedAt,
 		}
 	}
 


### PR DESCRIPTION
It's possible to have a scan status here but not an analysis, this allows us to use fallback created_at and updated_at timestamps for the response.