### PR TITLE
add an empty string check for outdated dependencies

### DIFF
--- a/digests/dependencies.go
+++ b/digests/dependencies.go
@@ -29,7 +29,7 @@ func nv(d *scans.Dependency) *scans.Dependency {
 }
 
 func od(d *scans.Dependency) *scans.Dependency {
-	if d.Version < d.LatestVersion {
+	if d.Version < d.LatestVersion && d.Version != "" {
 		return d
 	}
 	if d.Dependencies != nil {


### PR DESCRIPTION
See here on ingest https://github.com/ion-channel/doozers/blob/76185caf20c3dcc5ddc91330cc17affced501f42/lib/doozers/dependency.rb#L87
 doozer calculates to check if specified verison is 0, we should also do an check for empty requirement. 