### PR TITLE
Update ruleset history to include the changed from and changed to items.

### DIFF
--- a/projects/projects.go
+++ b/projects/projects.go
@@ -74,9 +74,10 @@ type Project struct {
 
 // ProjectRulesetHistory represents the ruleset history of a project
 type ProjectRulesetHistory struct {
-	RulesetID string    `json:"ruleset_id"`
-	CreatedAt time.Time `json:"created_at"`
-	UserID    string    `json:"user_id"`
+	NewRulesetID string    `json:"new_ruleset_id"`
+	OldRulesetID string    `json:"old_ruleset_id"`
+	CreatedAt    time.Time `json:"created_at"`
+	UserID       string    `json:"user_id"`
 }
 
 // RulesetID represents a ruleset ID


### PR DESCRIPTION
Makes the audit trail of who changed what, when, on rulesets easier to follow/display.