### PR TITLE
update response Meta to include correctly marshalled timestamp

### DIFF
--- a/responses/responses.go
+++ b/responses/responses.go
@@ -18,10 +18,10 @@ type IonResponse struct {
 
 // Meta represents the metadata section of an IonResponse
 type Meta struct {
-	TotalCount int       `json:"total_count"`
-	Limit      int       `json:"limit,omitempty"`
-	Offset     int       `json:"offset"`
-	LastUpdate time.Time `json:"last_update,omitempty"`
+	TotalCount int        `json:"total_count"`
+	Limit      int        `json:"limit,omitempty"`
+	Offset     int        `json:"offset"`
+	LastUpdate *time.Time `json:"last_update,omitempty"`
 }
 
 // NewResponse takes a data object, meta object, and desired status code to


### PR DESCRIPTION
- Updates `responses/responses.go`, updates `Meta` struct to safely use `omitempty` with `time.Time` type. 
For context: time.Time can't be used with `omitempty` (as it will come across as year 1 of `"0001-01-01T00:00:00Z"`) when marshall/unmarshalling.

See example of this [here](https://play.golang.org/p/L5cXqrYoq7M)