### PR TITLE
update analysisStatus to track project unreachable status

### DIFF
--- a/scanner/analysis_status.go
+++ b/scanner/analysis_status.go
@@ -39,16 +39,17 @@ const (
 
 // AnalysisStatus is a representation of an Ion Channel Analysis Status within the system
 type AnalysisStatus struct {
-	ID         string              `json:"id"`
-	TeamID     string              `json:"team_id"`
-	ProjectID  string              `json:"project_id"`
-	Message    string              `json:"message"`
-	Branch     string              `json:"branch"`
-	Status     string              `json:"status"`
-	CreatedAt  time.Time           `json:"created_at"`
-	UpdatedAt  time.Time           `json:"updated_at"`
-	ScanStatus []ScanStatus        `json:"scan_status"`
-	Deliveries map[string]Delivery `json:"deliveries"`
+	ID               string              `json:"id"`
+	TeamID           string              `json:"team_id"`
+	ProjectID        string              `json:"project_id"`
+	Message          string              `json:"message"`
+	Branch           string              `json:"branch"`
+	Status           string              `json:"status"`
+	UnreachableError bool                `json:"unreachable_error"`
+	CreatedAt        time.Time           `json:"created_at"`
+	UpdatedAt        time.Time           `json:"updated_at"`
+	ScanStatus       []ScanStatus        `json:"scan_status"`
+	Deliveries       map[string]Delivery `json:"deliveries"`
 }
 
 // Done indicates an analyse has stopped processing

--- a/scanner/analysis_status_test.go
+++ b/scanner/analysis_status_test.go
@@ -13,7 +13,7 @@ func TestEvaluation(t *testing.T) {
 
 	g.Describe("AnalysisStatus", func() {
 
-		g.It("should provide a simple function for determining done stati", func() {
+		g.It("should provide a simple function for determining done status", func() {
 			a := &AnalysisStatus{
 				Status: AnalysisStatusErrored,
 			}
@@ -21,7 +21,7 @@ func TestEvaluation(t *testing.T) {
 			Expect(a.Done()).To(BeTrue())
 		})
 
-		g.It("should provide a simple function for determining not done stati", func() {
+		g.It("should provide a simple function for determining not done status", func() {
 			a := &AnalysisStatus{
 				Status: AnalysisStatusAnalyzing,
 			}


### PR DESCRIPTION
Updates `analysis_status.go`, adding property to track unreachable error in the `AnalysisStatus` struct. 