### PR TITLE
[ION-563] update docs github action, remove duplicate install cmd for…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
 
     - name: Setup
-      run: brew install pandoc awscli
+      run: brew install pandoc
 
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
- Updates `.github/workflows/build.yml` github actions, to fix broken docs command. (brew install fails as osx already has the package installed see release notes here: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md)