### PR TITLE
[ION-568] remove outdated dep string compare

### DIFF
--- a/digests/dependencies_test.go
+++ b/digests/dependencies_test.go
@@ -1,6 +1,7 @@
 package digests
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ion-channel/ionic/scanner"
@@ -137,12 +138,18 @@ func TestDependenciesDigests(t *testing.T) {
 						},
 						scans.Dependency{
 							Name:          "ExpectVersion1",
-							Version:       "1.1.1",
-							LatestVersion: "2.0.0",
-							Requirement:   "1.1.1",
+							Version:       "5.9.1",
+							LatestVersion: "5.14.2",
+							Requirement:   "5.1",
 						},
 						scans.Dependency{
 							Name:          "ExpectVersion2",
+							Version:       "0.9.9.6",
+							LatestVersion: "0.13.1",
+							Requirement:   "0",
+						},
+						scans.Dependency{
+							Name:          "ExpectVersion3",
 							Version:       "10",
 							LatestVersion: "10",
 							Requirement:   "10",
@@ -179,7 +186,7 @@ func TestDependenciesDigests(t *testing.T) {
 			Expect(string(ds[0].Data)).To(Equal(`{"count":2}`))
 
 			// ds[0] is dependencies outdated
-			ds0Source := `{"type":"dependency","data":[{"latest_version":"2.0.0","org":"","name":"ExpectVersion1","type":"","package":"","version":"1.1.1","scope":"","requirement":"1.1.1","file":"","dependency_counts":{"first_degree_count":0,"no_version_count":0,"total_unique_count":0,"update_available_count":0,"vulnerable_count":0},"outdated_version":{"major_behind":1,"minor_behind":0,"patch_behind":0},"dependencies":[]},{"latest_version":"10","org":"","name":"ExpectVersion2","type":"","package":"","version":"10","scope":"","requirement":"10","file":"","dependency_counts":{"first_degree_count":0,"no_version_count":0,"total_unique_count":0,"update_available_count":2,"vulnerable_count":0},"dependencies":[{"latest_version":"2.0.0","org":"","name":"ExpectVersionTDep1","type":"","package":"","version":"1.1.1","scope":"","requirement":"1.1.1","file":"","outdated_version":{"major_behind":1,"minor_behind":0,"patch_behind":0},"dependencies":null},{"latest_version":"1.5.0","org":"","name":"ExpectVersionTDep2","type":"","package":"","version":"1.0.0","scope":"","requirement":"1.0.0","file":"","outdated_version":{"major_behind":0,"minor_behind":5,"patch_behind":0},"dependencies":null}]}]}`
+			ds0Source := `{"type":"dependency","data":[{"latest_version":"5.14.2","org":"","name":"ExpectVersion1","type":"","package":"","version":"5.9.1","scope":"","requirement":"5.1","file":"","dependency_counts":{"first_degree_count":0,"no_version_count":0,"total_unique_count":0,"update_available_count":0,"vulnerable_count":0},"outdated_version":{"major_behind":0,"minor_behind":5,"patch_behind":1},"dependencies":[]},{"latest_version":"0.13.1","org":"","name":"ExpectVersion2","type":"","package":"","version":"0.9.9.6","scope":"","requirement":"0","file":"","dependency_counts":{"first_degree_count":0,"no_version_count":0,"total_unique_count":0,"update_available_count":0,"vulnerable_count":0},"outdated_version":{"major_behind":0,"minor_behind":4,"patch_behind":0},"dependencies":[]},{"latest_version":"10","org":"","name":"ExpectVersion3","type":"","package":"","version":"10","scope":"","requirement":"10","file":"","dependency_counts":{"first_degree_count":0,"no_version_count":0,"total_unique_count":0,"update_available_count":2,"vulnerable_count":0},"dependencies":[{"latest_version":"2.0.0","org":"","name":"ExpectVersionTDep1","type":"","package":"","version":"1.1.1","scope":"","requirement":"1.1.1","file":"","outdated_version":{"major_behind":1,"minor_behind":0,"patch_behind":0},"dependencies":null},{"latest_version":"1.5.0","org":"","name":"ExpectVersionTDep2","type":"","package":"","version":"1.0.0","scope":"","requirement":"1.0.0","file":"","outdated_version":{"major_behind":0,"minor_behind":5,"patch_behind":0},"dependencies":null}]}]}`
 			//fmt.Printf("\nds0 source is %+v\n\nexpected is   %+v\n", string(ds[0].SourceData), ds0Source)
 			Expect(string(ds[0].SourceData)).To(Equal(ds0Source))
 
@@ -187,8 +194,8 @@ func TestDependenciesDigests(t *testing.T) {
 			// fmt.Printf("\n------\nds1 source is %+v\n\nexpected is   %+v\n", string(ds[1].SourceData), ds1Source)
 			Expect(string(ds[1].SourceData)).To(Equal(ds1Source))
 
-			ds2Source := `{"type":"dependency","data":[{"latest_version":"3.0.0","org":"","name":"UpToDate","type":"","package":"","version":"3.0.0","scope":"","requirement":"","file":"","dependencies":null},{"latest_version":"2.0.0","org":"","name":"ExpectVersion1","type":"","package":"","version":"1.1.1","scope":"","requirement":"1.1.1","file":"","dependencies":null},{"latest_version":"10","org":"","name":"ExpectVersion2","type":"","package":"","version":"10","scope":"","requirement":"10","file":"","dependencies":null}]}`
-			// fmt.Printf("\n------\nds2 source is %+v\n\nexpected is   %+v\n", string(ds[2].SourceData), ds2Source)
+			ds2Source := `{"type":"dependency","data":[{"latest_version":"3.0.0","org":"","name":"UpToDate","type":"","package":"","version":"3.0.0","scope":"","requirement":"","file":"","dependencies":null},{"latest_version":"5.14.2","org":"","name":"ExpectVersion1","type":"","package":"","version":"5.9.1","scope":"","requirement":"5.1","file":"","dependencies":null},{"latest_version":"0.13.1","org":"","name":"ExpectVersion2","type":"","package":"","version":"0.9.9.6","scope":"","requirement":"0","file":"","dependencies":null},{"latest_version":"10","org":"","name":"ExpectVersion3","type":"","package":"","version":"10","scope":"","requirement":"10","file":"","dependencies":null}]}`
+			fmt.Printf("\n------\nds2 source is %+v\n\nexpected is   %+v\n", string(ds[2].SourceData), ds2Source)
 			Expect(string(ds[2].SourceData)).To(Equal(ds2Source))
 
 			Expect(ds[0].Warning).To(BeFalse())


### PR DESCRIPTION
- Update `digests/dependencies.go`, remove string comparison for outdated versions, compare on SemVer instead.
  - updates `dependencies_test.go`

 (for example: https://play.golang.org/p/NlF8WyplAyY versions like `5.14.x` and 5.9.x` would not count as "outdated" if the string compare was present).