### PR TITLE
cleanup dependency test output, move to expected block

### DIFF
--- a/digests/dependencies_test.go
+++ b/digests/dependencies_test.go
@@ -1,7 +1,6 @@
 package digests
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/ion-channel/ionic/scanner"
@@ -187,16 +186,15 @@ func TestDependenciesDigests(t *testing.T) {
 
 			// ds[0] is dependencies outdated
 			ds0Source := `{"type":"dependency","data":[{"latest_version":"5.14.2","org":"","name":"ExpectVersion1","type":"","package":"","version":"5.9.1","scope":"","requirement":"5.1","file":"","dependency_counts":{"first_degree_count":0,"no_version_count":0,"total_unique_count":0,"update_available_count":0,"vulnerable_count":0},"outdated_version":{"major_behind":0,"minor_behind":5,"patch_behind":1},"dependencies":[]},{"latest_version":"0.13.1","org":"","name":"ExpectVersion2","type":"","package":"","version":"0.9.9.6","scope":"","requirement":"0","file":"","dependency_counts":{"first_degree_count":0,"no_version_count":0,"total_unique_count":0,"update_available_count":0,"vulnerable_count":0},"outdated_version":{"major_behind":0,"minor_behind":4,"patch_behind":0},"dependencies":[]},{"latest_version":"10","org":"","name":"ExpectVersion3","type":"","package":"","version":"10","scope":"","requirement":"10","file":"","dependency_counts":{"first_degree_count":0,"no_version_count":0,"total_unique_count":0,"update_available_count":2,"vulnerable_count":0},"dependencies":[{"latest_version":"2.0.0","org":"","name":"ExpectVersionTDep1","type":"","package":"","version":"1.1.1","scope":"","requirement":"1.1.1","file":"","outdated_version":{"major_behind":1,"minor_behind":0,"patch_behind":0},"dependencies":null},{"latest_version":"1.5.0","org":"","name":"ExpectVersionTDep2","type":"","package":"","version":"1.0.0","scope":"","requirement":"1.0.0","file":"","outdated_version":{"major_behind":0,"minor_behind":5,"patch_behind":0},"dependencies":null}]}]}`
-			//fmt.Printf("\nds0 source is %+v\n\nexpected is   %+v\n", string(ds[0].SourceData), ds0Source)
-			Expect(string(ds[0].SourceData)).To(Equal(ds0Source))
+			Expect(string(ds[0].SourceData)).To(Equal(ds0Source), "\nds0 source is %+v\n\nexpected is   %+v\n", string(ds[0].SourceData), ds0Source)
 
+			// transitive deps
 			ds1Source := `{"type":"dependency","data":[{"latest_version":"3.0.0","org":"","name":"UpToDate","type":"","package":"","version":"3.0.0","scope":"","requirement":"","file":"","dependencies":null}]}`
-			// fmt.Printf("\n------\nds1 source is %+v\n\nexpected is   %+v\n", string(ds[1].SourceData), ds1Source)
-			Expect(string(ds[1].SourceData)).To(Equal(ds1Source))
+			Expect(string(ds[1].SourceData)).To(Equal(ds1Source), "\n------\nds1 source is %+v\n\nexpected is   %+v\n", string(ds[1].SourceData), ds1Source)
 
+			// direct deps
 			ds2Source := `{"type":"dependency","data":[{"latest_version":"3.0.0","org":"","name":"UpToDate","type":"","package":"","version":"3.0.0","scope":"","requirement":"","file":"","dependencies":null},{"latest_version":"5.14.2","org":"","name":"ExpectVersion1","type":"","package":"","version":"5.9.1","scope":"","requirement":"5.1","file":"","dependencies":null},{"latest_version":"0.13.1","org":"","name":"ExpectVersion2","type":"","package":"","version":"0.9.9.6","scope":"","requirement":"0","file":"","dependencies":null},{"latest_version":"10","org":"","name":"ExpectVersion3","type":"","package":"","version":"10","scope":"","requirement":"10","file":"","dependencies":null}]}`
-			fmt.Printf("\n------\nds2 source is %+v\n\nexpected is   %+v\n", string(ds[2].SourceData), ds2Source)
-			Expect(string(ds[2].SourceData)).To(Equal(ds2Source))
+			Expect(string(ds[2].SourceData)).To(Equal(ds2Source), "\n------\nds2 source is %+v\n\nexpected is   %+v\n", string(ds[2].SourceData), ds2Source)
 
 			Expect(ds[0].Warning).To(BeFalse())
 			Expect(ds[0].Pending).To(BeFalse())


### PR DESCRIPTION
- Updates `digests/dependencies_test.go`, cleans up test output moves to Expect() block. Remove print statements.