### PR TITLE
Make digests work for next major version behind rule.

### DIFF
--- a/digests/dependencies.go
+++ b/digests/dependencies.go
@@ -193,7 +193,7 @@ func dependencyDigests(status *scanner.ScanStatus, eval *scans.Evaluation) ([]Di
 		// While the "more than one major version behind" rule is a dependency rule we don't
 		// want to apply it to this digest.
 		// As more rules of that type are created we'll add them to this if statement:
-		if eval.RuleID == "c0526ccb-d7b5-498f-8049-41741913bc73" {
+		if eval.RuleID == "c0526ccb-d7b5-498f-8049-41741913bc73" || eval.RuleID == "732cb8eb-6fa9-4c33-8d42-e3a8cfc1b231" {
 			d.Warning = false
 			d.Evaluated = false
 			d.PassedMessage = ""


### PR DESCRIPTION
Like https://github.com/ion-channel/ionic/pull/440 but for the next rule in the same vein.

I'd like to get the service PR merged before this one.