### PR TITLE
[ION-575] update community results to include committed at time

### DIFF
--- a/digests/community.go
+++ b/digests/community.go
@@ -11,6 +11,7 @@ func communityDigests(status *scanner.ScanStatus, eval *scans.Evaluation) ([]Dig
 	digests := make([]Digest, 0)
 
 	d := NewDigest(status, UniqueCommittersIndex, "unique committer", "unique committers")
+	activityDigest := NewDigest(status, CommittedAtIndex, "committed at", "committed at")
 
 	if eval != nil && !status.Errored() {
 		b, ok := eval.TranslatedResults.Data.(scans.CommunityResults)
@@ -27,9 +28,16 @@ func communityDigests(status *scanner.ScanStatus, eval *scans.Evaluation) ([]Dig
 			d.Warning = true
 			d.WarningMessage = "single committer repository"
 		}
+
+		activityDigest.MarshalSourceData(b, "committed at")
+		err = activityDigest.AppendEval(eval, "chars", b.CommittedAt.String())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create committed at digest: %v", err.Error())
+		}
 	}
 
 	digests = append(digests, *d)
+	digests = append(digests, *activityDigest)
 
 	return digests, nil
 }

--- a/digests/community_test.go
+++ b/digests/community_test.go
@@ -1,7 +1,9 @@
 package digests
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/ion-channel/ionic/scanner"
 	"github.com/ion-channel/ionic/scans"
@@ -19,21 +21,27 @@ func TestCommunityDigests(t *testing.T) {
 			s := &scanner.ScanStatus{}
 			s.Status = scanner.ScanStatusFinished
 			e := scans.NewEval()
+			committedAt := time.Now()
 			e.TranslatedResults = &scans.TranslatedResults{
 				Type: "community",
 				Data: scans.CommunityResults{
-					Committers: 123321,
+					Committers:  123321,
+					CommittedAt: committedAt,
 				},
 			}
 
 			ds, err := communityDigests(s, e)
 			Expect(err).To(BeNil())
-			Expect(len(ds)).To(Equal(1))
+			Expect(len(ds)).To(Equal(2))
 
 			Expect(ds[0].Title).To(Equal("unique committers"))
 			Expect(string(ds[0].Data)).To(Equal(`{"count":123321}`))
 			Expect(ds[0].Pending).To(BeFalse())
 			Expect(ds[0].Errored).To(BeFalse())
+
+			Expect(ds[1].Title).To(Equal("committed at"))
+			res := fmt.Sprintf("{\"chars\":\"%s\"}", committedAt.String())
+			Expect(string(ds[1].Data)).To(Equal(res))
 		})
 
 		g.It("should warn about single committer repos", func() {
@@ -49,7 +57,7 @@ func TestCommunityDigests(t *testing.T) {
 
 			ds, err := communityDigests(s, e)
 			Expect(err).To(BeNil())
-			Expect(len(ds)).To(Equal(1))
+			Expect(len(ds)).To(Equal(2))
 
 			Expect(ds[0].Title).To(Equal("unique committer"))
 			Expect(string(ds[0].Data)).To(Equal(`{"count":1}`))

--- a/digests/digests.go
+++ b/digests/digests.go
@@ -47,6 +47,8 @@ const (
 	UniqueCommittersIndex
 	//CodeCoverageIndex represents the index number for this digest type
 	CodeCoverageIndex
+	//CommittedAtIndex represents the index number for this digest type
+	CommittedAtIndex
 )
 
 // GroupedDigests represents an organized grouped report of digests

--- a/scans/results.go
+++ b/scans/results.go
@@ -287,9 +287,10 @@ type BuildsystemResults struct {
 // CommunityResults represents the data collected from a community scan.  It
 // represents all known data regarding the open community of a software project
 type CommunityResults struct {
-	Committers int    `json:"committers" xml:"committers"`
-	Name       string `json:"name" xml:"name"`
-	URL        string `json:"url" xml:"url"`
+	Committers  int       `json:"committers" xml:"committers"`
+	Name        string    `json:"name" xml:"name"`
+	URL         string    `json:"url" xml:"url"`
+	CommittedAt time.Time `json:"committed_at" xml:"committed_at"`
 }
 
 // CoverageResults represents the data collected from a code coverage scan.  It


### PR DESCRIPTION
- updates `results.go`, `CommunityResults` struct updating to use committed_at time so it can be propagated through from scan data