### PR TITLE
[ION-575] update community results to include last updated time

### DIFF
--- a/digests/community.go
+++ b/digests/community.go
@@ -2,6 +2,8 @@ package digests
 
 import (
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/ion-channel/ionic/scanner"
 	"github.com/ion-channel/ionic/scans"
@@ -9,8 +11,8 @@ import (
 
 func communityDigests(status *scanner.ScanStatus, eval *scans.Evaluation) ([]Digest, error) {
 	digests := make([]Digest, 0)
-
 	d := NewDigest(status, UniqueCommittersIndex, "unique committer", "unique committers")
+	activityDigest := NewDigest(status, CommittedAtIndex, "days since last commit", "days since last commit")
 
 	if eval != nil && !status.Errored() {
 		b, ok := eval.TranslatedResults.Data.(scans.CommunityResults)
@@ -31,5 +33,32 @@ func communityDigests(status *scanner.ScanStatus, eval *scans.Evaluation) ([]Dig
 
 	digests = append(digests, *d)
 
+	if eval != nil && !status.Errored() {
+		b, ok := eval.TranslatedResults.Data.(scans.CommunityResults)
+		if !ok {
+			return nil, fmt.Errorf("error coercing evaluation translated results into community")
+		}
+
+		activityDigest.MarshalSourceData(b, "committed at")
+
+		var evalDaysSinceLastCommit string
+		committedAt := b.CommittedAt
+		now := time.Now()
+		difference := now.Sub(committedAt)
+		daysSinceLastCommmit := int(difference.Hours() / 24)
+		evalDaysSinceLastCommit = strconv.Itoa(daysSinceLastCommmit)
+
+		// check for legacy scans (as they won't have this data availible), otherwise display days since last committed at
+		if b.CommittedAt.IsZero() {
+			evalDaysSinceLastCommit = "N/A"
+		}
+
+		err := activityDigest.AppendEval(eval, "chars", evalDaysSinceLastCommit)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create committed at digest: %v", err.Error())
+		}
+	}
+
+	digests = append(digests, *activityDigest)
 	return digests, nil
 }

--- a/digests/digests.go
+++ b/digests/digests.go
@@ -47,6 +47,8 @@ const (
 	UniqueCommittersIndex
 	//CodeCoverageIndex represents the index number for this digest type
 	CodeCoverageIndex
+	//CommittedAtIndex represents the index number for this digest type
+	CommittedAtIndex
 )
 
 // GroupedDigests represents an organized grouped report of digests

--- a/scans/results.go
+++ b/scans/results.go
@@ -287,9 +287,10 @@ type BuildsystemResults struct {
 // CommunityResults represents the data collected from a community scan.  It
 // represents all known data regarding the open community of a software project
 type CommunityResults struct {
-	Committers int    `json:"committers" xml:"committers"`
-	Name       string `json:"name" xml:"name"`
-	URL        string `json:"url" xml:"url"`
+	Committers  int       `json:"committers" xml:"committers"`
+	Name        string    `json:"name" xml:"name"`
+	URL         string    `json:"url" xml:"url"`
+	CommittedAt time.Time `json:"committed_at" xml:"committed_at"`
 }
 
 // CoverageResults represents the data collected from a code coverage scan.  It


### PR DESCRIPTION
- Updates `digests/community.go` updating community digest, update to handle handle legacy scans, update to change digest to "days since last commit".
  - update tests
  