### PR TITLE
Add GetAppliedRuleSetsBrief

### DIFF
--- a/reports/project.go
+++ b/reports/project.go
@@ -109,8 +109,8 @@ func NewProjectReports(input NewProjectReportsInput, defaultRulesetName string) 
 
 	projectStatus := ProjectStatusPending
 	rulesetName := defaultRulesetName
-	if appliedRuleset != nil && appliedRuleset.RuleEvaluationSummary != nil {
-		rulesetName = appliedRuleset.RuleEvaluationSummary.RulesetName
+	if appliedRuleset != nil {
+		rulesetName = appliedRuleset.RulesetName
 	}
 
 	if analysisStatus != nil {

--- a/reports/project_test.go
+++ b/reports/project_test.go
@@ -55,6 +55,7 @@ func TestProjectReport(t *testing.T) {
 					RulesetName: expectedRulesetName,
 					Summary:     "pass",
 				},
+				RulesetName: expectedRulesetName,
 			}
 
 			as := &scanner.AnalysisStatus{

--- a/rulesets.go
+++ b/rulesets.go
@@ -79,6 +79,32 @@ func (ic *IonClient) GetAppliedRuleSets(appliedRequestBatch []*rulesets.AppliedR
 	return &s, nil
 }
 
+// GetAppliedRuleSetsBrief takes a slice of AppliedRulesetRequest and returns their applied ruleset results in
+// brief/summarized form, omitting any not found
+func (ic *IonClient) GetAppliedRuleSetsBrief(appliedRequestBatch []*rulesets.AppliedRulesetRequest, token string) (*[]rulesets.AppliedRulesetSummary, error) {
+	b, err := json.Marshal(appliedRequestBatch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal project: %v", err.Error())
+	}
+
+	params := &url.Values{}
+	params.Add("summarized", "true")
+
+	buff := bytes.NewBuffer(b)
+	r, err := ic.Post(rulesets.GetBatchAppliedRulesetEndpoint, token, params, *buff, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get applied ruleset summary: %v", err.Error())
+	}
+
+	var s []rulesets.AppliedRulesetSummary
+	err = json.Unmarshal(r, &s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal applied ruleset summary: %v", err.Error())
+	}
+
+	return &s, nil
+}
+
 //GetRawAppliedRuleSet takes a projectID, teamID, analysisID, and page definition and returns the corresponding applied ruleset summary json or an error encountered by the API
 func (ic *IonClient) GetRawAppliedRuleSet(projectID, teamID, analysisID, token string, page *pagination.Pagination) (json.RawMessage, error) {
 	params := &url.Values{}

--- a/rulesets/applied_rulesets.go
+++ b/rulesets/applied_rulesets.go
@@ -18,6 +18,8 @@ type AppliedRulesetSummary struct {
 	ProjectID             string                 `json:"project_id"`
 	TeamID                string                 `json:"team_id"`
 	AnalysisID            string                 `json:"analysis_id"`
+	RulesetID             string                 `json:"ruleset_id"`
+	RulesetName           string                 `json:"ruleset_name"`
 	RuleEvaluationSummary *RuleEvaluationSummary `json:"rule_evaluation_summary"`
 	CreatedAt             time.Time              `json:"created_at"`
 	UpdatedAt             time.Time              `json:"updated_at"`


### PR DESCRIPTION
Adds a method to retrieve less information about applied rulesets. The main GetAppliedRuleSets method can return tons of data that you don't necessarily need.