### PR TITLE
[ION-845] Fix bug in project source after SPDX import

### DIFF
--- a/spdx/spdx.go
+++ b/spdx/spdx.go
@@ -148,6 +148,8 @@ func ProjectsFromSPDX(doc interface{}, includeDependencies bool) ([]projects.Pro
 				if !strings.Contains(possibleBranch, ":") && !commitHashRegex.MatchString(possibleBranch) {
 					branch = possibleBranch
 					foundBranchName = true
+					// now we need to remove the branch name from the source
+					source = source[0:branchDelimiterIndex]
 				}
 			}
 			if !foundBranchName {

--- a/spdx/spdx_test.go
+++ b/spdx/spdx_test.go
@@ -73,6 +73,7 @@ func TestSPDX(t *testing.T) {
 			Expect(len(p[0].Aliases)).To(Equal(1))
 			Expect(p[0].Aliases[0].Version).To(Equal(spdxPackage.PackageVersion))
 			Expect(*p[0].Branch).To(Equal("main"))
+			Expect(*p[0].Source).To(Equal("https://github.com/some-org/some-cool-pkg.git"))
 		})
 
 		g.It("should return all projects when dependencies requested", func() {


### PR DESCRIPTION
Wasn't stripping the '@branch-name' at the end of a git URL, which was causing analyses to fail.