### PR TITLE
[ION-1081] Filter duplicate projects when parsing SBOM to projects

### DIFF
--- a/aliases/aliases.go
+++ b/aliases/aliases.go
@@ -16,3 +16,13 @@ const (
 	// AddAliasEndpoint allows the user to attach an alias to a project.  Consists of org, name, version. Requires team id and project id.
 	AddAliasEndpoint = "v1/project/addAlias"
 )
+
+// Equal checks if a given Alias is equivalent to another Alias, based on the name, org, and version information
+// they contain. Returns true if they are equivalent.
+func (a Alias) Equal(x Alias) bool {
+	if a.Name == x.Name && a.Version == x.Version && a.Org == x.Org {
+		return true
+	}
+
+	return false
+}

--- a/cyclonedx/cyclonedx.go
+++ b/cyclonedx/cyclonedx.go
@@ -45,7 +45,7 @@ func fromString(sbomContents string, fileType cyclonedx.BOMFileFormat) (*cyclone
 
 func projectFromComponent(component cyclonedx.Component) projects.Project {
 	var projectAliases []aliases.Alias
-	if len(component.Name) > 0 && len(component.Publisher) > 0 && len(component.Version) > 0 {
+	if len(component.Name) > 0 || len(component.Publisher) > 0 || len(component.Version) > 0 {
 		projectAliases = []aliases.Alias{{
 			Name:    component.Name,
 			Org:     component.Publisher,

--- a/projects/projects.go
+++ b/projects/projects.go
@@ -461,3 +461,39 @@ func (pf *Filter) Param() string {
 
 	return strings.Join(ps, ",")
 }
+
+// ProjectSliceContains checks if a given []Project contains a Project matching the given Project.
+// This is used to prevent duplicate Projects from appearing in a slice of Projects.
+// This function checks the project's aliases (if available), as well as the source location.
+// Returns true if a match is found.
+func ProjectSliceContains(projects []Project, projectToFind Project) bool {
+	// don't bother checking aliases if the project we're looking for doesn't have any
+	var useAliases bool
+	if len(projectToFind.Aliases) > 0 {
+		useAliases = true
+	}
+
+	for _, project := range projects {
+		// if both projects contain aliases, check all the aliases against each other to see if any are equivalent
+		if useAliases {
+			for _, alias := range project.Aliases {
+				for _, aliasToFind := range projectToFind.Aliases {
+					if alias.Equal(aliasToFind) {
+						return true
+					}
+				}
+			}
+		}
+
+		// check if both projects contain the same source information
+		if project.Type != nil && projectToFind.Type != nil && *project.Type != "" &&
+			*project.Type == *projectToFind.Type {
+			if project.Source != nil && projectToFind.Source != nil && *project.Source != "" &&
+				*project.Source == *projectToFind.Source {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/projects/projects_test.go
+++ b/projects/projects_test.go
@@ -3,6 +3,7 @@ package projects
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/ion-channel/ionic/aliases"
 	"net/http"
 	"net/url"
 	"testing"
@@ -435,6 +436,70 @@ func TestProject(t *testing.T) {
 				Expect(*newPf.ID).To(Equal("coolproject"))
 				Expect(newPf.IDs).NotTo(BeNil())
 				Expect(*newPf.IDs).To(Equal([]string{"aaaa", "bbbb", "cccc"}))
+			})
+		})
+		g.Describe("ProjectSliceContains", func() {
+			g.It("should return true when project with matching alias found in slice", func() {
+				project := Project{Aliases: []aliases.Alias{{
+					Name:    "some project",
+					Version: "1.0.0",
+					Org:     "Ion Channel",
+				}}}
+
+				projectList := []Project{project}
+
+				Expect(ProjectSliceContains(projectList, project)).To(BeTrue())
+			})
+
+			g.It("should return false when no projects with matching aliases found in slice", func() {
+				project := Project{Aliases: []aliases.Alias{{
+					Name:    "some project",
+					Version: "1.0.0",
+					Org:     "Ion Channel",
+				}}}
+
+				project2 := Project{Aliases: []aliases.Alias{{
+					Name:    "some other project",
+					Version: "1.0.1",
+					Org:     "Ion Channel",
+				}}}
+
+				projectList := []Project{project}
+
+				Expect(ProjectSliceContains(projectList, project2)).To(BeFalse())
+			})
+
+			g.It("should return true when project with matching source found in slice", func() {
+				pType := "git"
+				pSource := "https://github.com/ion-channel/ionic"
+				project := Project{
+					Type:   &pType,
+					Source: &pSource,
+				}
+
+				projectList := []Project{project}
+
+				Expect(ProjectSliceContains(projectList, project)).To(BeTrue())
+			})
+
+			g.It("should return false when no projects with matching source found in slice", func() {
+				pType := "git"
+				pSource := "https://github.com/ion-channel/ionic"
+				project := Project{
+					Type:   &pType,
+					Source: &pSource,
+				}
+
+				pType2 := "git"
+				pSource2 := "https://github.com/facebook/react"
+				project2 := Project{
+					Type:   &pType2,
+					Source: &pSource2,
+				}
+
+				projectList := []Project{project}
+
+				Expect(ProjectSliceContains(projectList, project2)).To(BeFalse())
 			})
 		})
 	})

--- a/spdx/spdx.go
+++ b/spdx/spdx.go
@@ -165,6 +165,11 @@ func ProjectsFromSPDX(doc interface{}, includeDependencies bool) ([]projects.Pro
 			}}
 		}
 
+		// make sure we don't already have an equivalent project
+		if projects.ProjectSliceContains(projs, proj) {
+			continue
+		}
+
 		projs = append(projs, proj)
 
 	}


### PR DESCRIPTION
If an SBOM contains a component multiple times, only create one project for that component.

For example, if multiple dependencies all share a transitive dependency, we would not want to create multiple of the exact same project for that transitive dependency.

Also changes the Project Alias generation behavior for CycloneDX to match SPDX's behavior. SPDX generates an Alias using any available information (name, version, OR org), but CycloneDX was only generating an Alias if we had the name, version, AND org.