### PR TITLE
[ION-1186] [ION-1218] Add additional fields to SBOMEntry

### DIFF
--- a/projects/sboms.go
+++ b/projects/sboms.go
@@ -48,6 +48,8 @@ type SBOMEntry struct {
 	ProductID      string        `json:"product_id"` // CPE
 	PackageID      string        `json:"package_id"` // PURL
 	Repo           string        `json:"repo"`
+	CreatedAt      time.Time     `json:"created_at"`
+	UpdatedAt      time.Time     `json:"updated_at"`
 }
 
 // SBOM represents a software list containing zero or more SBOMEntry objects.

--- a/projects/sboms.go
+++ b/projects/sboms.go
@@ -16,10 +16,26 @@ type SourceDetails struct {
 	Version string `json:"sbom_version"`
 }
 
+// SBOMEntryType represents a search result's type
+type SBOMEntryType string
+
+const (
+	// SBOMEntryTypePackage represents the Package search result type
+	SBOMEntryTypePackage SBOMEntryType = "package"
+	// SBOMEntryTypeRepo represents the Repo search result type
+	SBOMEntryTypeRepo SBOMEntryType = "repo"
+	// SBOMEntryTypeProduct represents the Product search result type
+	SBOMEntryTypeProduct SBOMEntryType = "product"
+	// SBOMEntryTypeError denotes that the search result represents an error.
+	// The error message can be found in the ErrMsg field
+	SBOMEntryTypeError SBOMEntryType = "error"
+)
+
 // SBOMEntry represents a single entry within an SBOM.
 type SBOMEntry struct {
 	ID             string        `json:"id"`
 	SBOMID         string        `json:"sbom_id"`
+	Type           string        `json:"type"`
 	Confidence     float32       `json:"confidence"`
 	Name           string        `json:"name"`
 	Org            string        `json:"org"`


### PR DESCRIPTION
[ION-1186] Allows us to differentiate between package, repo, and product search results.

[ION-1218] Facilitates backend work for ION-1218

[ION-1186]: https://ionchannel.atlassian.net/browse/ION-1186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ION-1218]: https://ionchannel.atlassian.net/browse/ION-1218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ