### PR TITLE
[ION-1292] [ION-1366] Additional SBOM export options, allow ingesting slightly invalid CycloneDX SBOMs

### DIFF
--- a/reports.go
+++ b/reports.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ion-channel/ionic/scanner"
 )
 
-//GetAnalysisReport takes an analysisID, teamID, projectID, and token. It
+// GetAnalysisReport takes an analysisID, teamID, projectID, and token. It
 // returns the corresponding analysis report or an error encountered by the API
 func (ic *IonClient) GetAnalysisReport(analysisID, teamID, projectID, token string) (*reports.AnalysisReport, error) {
 	params := url.Values{}
@@ -35,7 +35,7 @@ func (ic *IonClient) GetAnalysisReport(analysisID, teamID, projectID, token stri
 	return &r, nil
 }
 
-//GetRawAnalysisReport takes an analysisID, teamID, projectID, and token. It
+// GetRawAnalysisReport takes an analysisID, teamID, projectID, and token. It
 // returns the corresponding analysis report json or an error encountered by the
 // API
 func (ic *IonClient) GetRawAnalysisReport(analysisID, teamID, projectID, token string) (json.RawMessage, error) {
@@ -52,7 +52,7 @@ func (ic *IonClient) GetRawAnalysisReport(analysisID, teamID, projectID, token s
 	return b, nil
 }
 
-//GetProjectReport takes a projectID, a teamID, and token. It returns the
+// GetProjectReport takes a projectID, a teamID, and token. It returns the
 // corresponding project report or an error encountered by the API
 func (ic *IonClient) GetProjectReport(projectID, teamID, token string) (*reports.ProjectReport, error) {
 	params := url.Values{}
@@ -73,7 +73,7 @@ func (ic *IonClient) GetProjectReport(projectID, teamID, token string) (*reports
 	return &r, nil
 }
 
-//GetRawProjectReport takes a projectID, a teamID, and token. It returns the
+// GetRawProjectReport takes a projectID, a teamID, and token. It returns the
 // corresponding project report json or an error encountered by the API
 func (ic *IonClient) GetRawProjectReport(projectID, teamID, token string) (json.RawMessage, error) {
 	params := url.Values{}
@@ -171,13 +171,8 @@ func (ic *IonClient) GetExportedVulnerabilityData(ids []string, teamID, token st
 
 // GetSBOM takes slice of project ids, team id, SBOM format, and token.
 // Returns one or more SBOMs for the requested project(s).
-func (ic *IonClient) GetSBOM(ids []string, teamID string, options reports.SBOMExportOptions, token string) (string, error) {
-	body := requests.ByIDsAndTeamID{
-		TeamID: teamID,
-		IDs:    ids,
-	}
-
-	b, err := json.Marshal(body)
+func (ic *IonClient) GetSBOM(options reports.SBOMExportOptions, token string) (string, error) {
+	b, err := json.Marshal(options)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal request body: %v", err.Error())
 	}

--- a/reports/sbom.go
+++ b/reports/sbom.go
@@ -20,10 +20,26 @@ const (
 	SBOMFormatCycloneDX SBOMFormat = "CycloneDX"
 )
 
-// SBOMExportOptions represents all of the different settings a user can specify for how the SBOM is exported.
+// SBOMExportOptions represents all the different settings a user can specify for how the SBOM is exported.
+// Specify only one of the following data sources to generate the SBOM from:
+//  * ProjectIDs (a slice of one or more project IDs)
+//  * TeamID (the ID of a team containing one or more projects; this will use all the team's projects)
+//  * SBOMID (the ID of a software list containing one or more components; this will use all the list's components)
+//  * SBOMEntryIDs (a slice of one or more software list component IDs)
+// Format (required) specifies which format/standard the SBOM will be exported in.
+// IncludeDependencies will include all the direct and transitive dependencies of each item in the SBOM if true,
+// or exclude all the dependencies if false, leaving only the items themselves.
+// TeamIsTopLevel applies only to SBOMs generated using the TeamID field. If true, the top-level item in the SBOM's
+// hierarchy will be the team. If false, all the team's projects will be on the top level of the hierarchy.
 type SBOMExportOptions struct {
+	ProjectIDs   []string
+	TeamID       string
+	SBOMID       string
+	SBOMEntryIDs []string
+
 	Format              SBOMFormat
 	IncludeDependencies bool
+	TeamIsTopLevel      bool
 }
 
 // Params converts an SBOMExportOptions object into a URL param object for use in making an API request
@@ -31,6 +47,7 @@ func (options SBOMExportOptions) Params() url.Values {
 	params := url.Values{}
 	params.Set("sbom_type", string(options.Format))
 	params.Set("include_dependencies", strconv.FormatBool(options.IncludeDependencies))
+	params.Set("team_top_level", strconv.FormatBool(options.TeamIsTopLevel))
 
 	return params
 }


### PR DESCRIPTION
- Adds some additional options for exporting SBOMs
- Allows ingesting CycloneDX SBOMs that are missing the top-level component in the metadata (some tools generate SBOMs like this)