### PR TITLE
[ION-1292] Refactor getProjects

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -143,15 +143,10 @@ func (ic *IonClient) GetRawProject(id, teamID, token string) (json.RawMessage, e
 	return b, nil
 }
 
-// GetProjects takes a team ID and returns the projects for that team.  It
-// returns an error for any API errors it may encounter.
-func (ic *IonClient) GetProjects(teamID, token string, page pagination.Pagination, filter *projects.Filter) ([]projects.Project, error) {
+// GetProjects takes a project filter and returns a slice of the projects matching that filter, or an error.
+func (ic *IonClient) GetProjects(filter projects.Filter, token string, page pagination.Pagination) ([]projects.Project, error) {
 	params := url.Values{}
-	params.Set("team_id", teamID)
-
-	if filter != nil {
-		params.Set("filter_by", filter.Param())
-	}
+	params.Set("filter_by", filter.Param())
 
 	b, _, err := ic.Get(projects.GetProjectsEndpoint, token, params, nil, page)
 	if err != nil {

--- a/projects/projects.go
+++ b/projects/projects.go
@@ -342,15 +342,15 @@ type Filter struct {
 	// ID filters on a single ID
 	ID *string `sql:"id"`
 	// IDs filters on one or more IDs
-	IDs         *[]string `sql:"id"`
-	TeamID      *string   `sql:"team_id"`
-	SBOMID      *string   `sql:"sbom_id"`
-	SBOMEntryID *string   `sql:"sbom_entry_id"`
-	Source      *string   `sql:"source"`
-	Type        *string   `sql:"type"`
-	Active      *bool     `sql:"active"`
-	Draft       *bool     `sql:"draft"`
-	Monitor     *bool     `sql:"should_monitor"`
+	IDs          *[]string `sql:"id"`
+	TeamID       *string   `sql:"team_id"`
+	SBOMID       *string   `sql:"sbom_id"`
+	SBOMEntryIDs *[]string `sql:"sbom_entry_id"`
+	Source       *string   `sql:"source"`
+	Type         *string   `sql:"type"`
+	Active       *bool     `sql:"active"`
+	Draft        *bool     `sql:"draft"`
+	Monitor      *bool     `sql:"should_monitor"`
 }
 
 // ParseParam takes a param string, breaks it apart, and repopulates it into a

--- a/projects_test.go
+++ b/projects_test.go
@@ -73,7 +73,8 @@ func TestProjects(t *testing.T) {
 				SetPayload([]byte(SampleValidProjects)).
 				SetStatus(http.StatusOK)
 
-			projects, err := client.GetProjects("bef86653-1926-4990-8ef8-5f26cd59d6fc", "", pagination.Pagination{}, nil)
+			teamID := "bef86653-1926-4990-8ef8-5f26cd59d6fc"
+			projects, err := client.GetProjects(projects.Filter{TeamID: &teamID}, "", pagination.Pagination{})
 			Expect(err).To(BeNil())
 			Expect(len(projects)).To(Equal(2))
 			Expect(*projects[0].ID).To(Equal("334c183d-4d37-4515-84c4-0d0ed0fb8db0"))


### PR DESCRIPTION
The getProjects endpoint no longer requires the Team ID to be passed in for every request.

Moves the filter argument to be the first one in the function call.