### PR TITLE
[DEV-341] Add supported SBOM standards and encodings, rename Stats

### DIFF
--- a/projects/software_lists.go
+++ b/projects/software_lists.go
@@ -23,7 +23,7 @@ type SoftwareList struct {
 	UpdatedAt        time.Time   `json:"updated_at"`
 	DeletedAt        *time.Time  `json:"deleted_at"`
 	EntryCount       int         `json:"entry_count"`
-	Stats            Stats       `json:"stats"`
+	Metrics          Metrics     `json:"metrics"`
 	Entries          []Component `json:"entries"`
 	TeamID           string      `json:"team_id"`
 	OrgID            string      `json:"org_id"`
@@ -50,7 +50,7 @@ type Resolution struct {
 	Unresolved        int `json:"unresolved"`
 }
 
-type Stats struct {
+type Metrics struct {
 	Risk       Risk       `json:"risk"`
 	Compliance Compliance `json:"compliance"`
 	Resolution Resolution `json:"resolution"`
@@ -58,6 +58,6 @@ type Stats struct {
 
 type SoftwareInventorySummary struct {
 	ID            string         `json:"id"`
-	Organization  Stats          `json:"organization"`
+	Organization  Metrics        `json:"organization"`
 	SoftwareLists []SoftwareList `json:"softwareLists"`
 }

--- a/reports/sbom.go
+++ b/reports/sbom.go
@@ -10,16 +10,37 @@ const (
 	ReportExportSBOMEndpoint = "v1/report/getSBOM"
 )
 
-// SBOMFormat is a string enum for the accepted SBOM formats that we can export
-type SBOMFormat string
+// Standard is a string enum of supported SBOM standards
+type Standard string
+
+// Encoding is a string enum of supported file/data encoding standards
+type Encoding string
 
 const (
-	// SBOMFormatSPDX is the enum value for the SPDX SBOM format
-	SBOMFormatSPDX SBOMFormat = "SPDX"
-	// SBOMFormatCycloneDX is the enum value for the CycloneDX SBOM format
-	SBOMFormatCycloneDX SBOMFormat = "CycloneDX"
-	// SBOMFormatGitlab is the enum value for the Gitlab SBOM format
-	SBOMFormatGitlab SBOMFormat = "Gitlab"
+	// StandardUnknown denotes that the Standard is unknown
+	StandardUnknown Standard = "unknown"
+	// EncodingUnknown denotes that the Encoding is unknown
+	EncodingUnknown Encoding = "unknown"
+
+	// StandardCycloneDX indicates that the SBOM adheres to the CycloneDX standard
+	StandardCycloneDX Standard = "CycloneDX"
+	// StandardIonChannel indicates that the SBOM adheres to the Ion Channel standard
+	StandardIonChannel Standard = "IonChannel"
+	// StandardSPDX indicates that the SBOM adheres to the SPDX standard
+	StandardSPDX Standard = "SPDX"
+
+	// EncodingCSV indicates that the SBOM is stored in CSV format
+	EncodingCSV Encoding = "CSV"
+	// EncodingJSON indicates that the SBOM is stored in JSON format
+	EncodingJSON Encoding = "JSON"
+	// EncodingTagValue indicates that the SBOM is stored in tag-value format
+	EncodingTagValue Encoding = "tag-value"
+	// EncodingXLSX indicates that the SBOM is stored in XLSX format
+	EncodingXLSX Encoding = "XLSX"
+	// EncodingXML indicates that the SBOM is stored in XML format
+	EncodingXML Encoding = "XML"
+	// EncodingYAML indicates that the SBOM is stored in YAML format
+	EncodingYAML Encoding = "YAML"
 )
 
 // SBOMExportOptions represents all the different settings a user can specify for how the SBOM is exported.
@@ -39,15 +60,17 @@ type SBOMExportOptions struct {
 	SoftwareListID string   `json:"sbom_id"`
 	ComponentIDs   []string `json:"sbom_entry_ids"`
 
-	Format              SBOMFormat `json:"sbom_type"`
-	IncludeDependencies bool       `json:"include_dependencies"`
-	TeamIsTopLevel      bool       `json:"team_top_level"`
+	Standard            Standard `json:"sbom_type"`
+	Encoding            Encoding `json:"encoding"`
+	IncludeDependencies bool     `json:"include_dependencies"`
+	TeamIsTopLevel      bool     `json:"team_top_level"`
 }
 
 // Params converts an SBOMExportOptions object into a URL param object for use in making an API request
 func (options SBOMExportOptions) Params() url.Values {
 	params := url.Values{}
-	params.Set("sbom_type", string(options.Format))
+	params.Set("sbom_type", string(options.Standard))
+	params.Set("encoding", string(options.Encoding))
 	params.Set("include_dependencies", strconv.FormatBool(options.IncludeDependencies))
 	params.Set("team_top_level", strconv.FormatBool(options.TeamIsTopLevel))
 


### PR DESCRIPTION
Adds enums for supported SBOM standards and encodings.

Renames Stats struct back to Metrics (accidentally pushed outdated code)